### PR TITLE
added support for automatic PE arch parsing and fixed IDA local path 

### DIFF
--- a/filters/names.py
+++ b/filters/names.py
@@ -44,6 +44,8 @@ def filter(f, name, extension, arch, verbose=True):
         arch_ = 64
     elif arch == "32":
         arch_ = 32
+    elif arch == "auto":
+        arch_ = "auto"
     else:
         logmsg("Unknown architecture: %s. You need to specify it with -a" % arch)
         return None

--- a/idahunt.py
+++ b/idahunt.py
@@ -21,6 +21,7 @@ import subprocess
 import time
 import glob
 import filelock
+import struct
 
 def logmsg(s, end=None, debug=True):
     if not debug:
@@ -46,6 +47,35 @@ def iglob_hidden(*args, **kwargs):
 def path_to_module_string(p):
     return p.replace("/", ".").replace("\\", ".")
 
+def check_arch(filename):
+    IMAGE_FILE_MACHINE_I386=332
+    IMAGE_FILE_MACHINE_IA64=512
+    IMAGE_FILE_MACHINE_AMD64=34404
+    arch = None
+    f=open(filename, "rb")
+    s=f.read(2)
+    if s!=b"MZ":
+        print("Not an EXE file")
+    else:
+        f.seek(60)
+        s=f.read(4)
+        header_offset=struct.unpack("<L", s)[0]
+        f.seek(header_offset+4)
+        s=f.read(2)
+        machine=struct.unpack("<H", s)[0]
+        if machine==IMAGE_FILE_MACHINE_I386:
+            arch = 32
+        elif machine==IMAGE_FILE_MACHINE_IA64:
+            arch = 64
+        elif machine==IMAGE_FILE_MACHINE_AMD64:
+            arch = 64
+        else:
+            arch = None
+            logmsg("Unknown architecture detected")
+            sys.exit()
+        f.close()
+    return arch
+
 # Does the initial auto-analysis when we first open a file in IDA
 # Returns False if does not do anything, the subprocess if it was created
 # of True if it was listing only.
@@ -69,7 +99,7 @@ def analyse_file(ida_executable, infile, logfile, idbfile, verbose, ida_args=Non
         shell=False
 
     if not list_only:
-        return subprocess.Popen(cmd, shell)
+        return subprocess.Popen(cmd, shell=True)
     else:
         return True
 
@@ -188,10 +218,14 @@ def do_dir(inputdir, filter, verbose, max_ida, do_file, ida_args=None, script=No
             if res == None:
                 continue
             infile, arch = res
-            if arch == 32:
+
+            if arch == "auto":
+                arch_check_result = check_arch(f)
+
+            if (arch == 32) or (arch_check_result == 32):
                 ida_executable = IDA32
                 idbfile = f_noext + ".idb"
-            elif arch == 64:
+            elif (arch == 64) or (arch_check_result == 64):
                 ida_executable = IDA64
                 idbfile = f_noext + ".i64"
             else:
@@ -281,6 +315,8 @@ if __name__ == "__main__":
                         help='Maximum number of instances of IDA to run at a time (default: 10)')
     parser.add_argument('--list-only', dest='list_only', default=False, action="store_true",
                         help='List only what files would be handled without executing IDA')
+    parser.add_argument('--version', dest='ida_version', default=None,
+                        help='IDA version')
     args = parser.parse_args()
 
     if not args.analyse and not args.cleanup_temporary and \
@@ -292,6 +328,11 @@ if __name__ == "__main__":
     if args.list_only:
         logmsg("Simulating only...")
 
+    if not args.ida_version and not args.list_only:
+        logmsg("ERROR: You need to provide an IDA version with  --version")
+        sys.exit()
+
+    ida_version = args.ida_version
     ida32_found = False
     try:
         IDA32 = os.environ["IDA32"]
@@ -312,7 +353,7 @@ if __name__ == "__main__":
                     pass
         else:
             #IDA32="C:\\Program Files (x86)\\IDA 6.95\\idaq.exe"
-            IDA32="C:\\Program Files\\IDA 7.2\\ida.exe"
+            IDA32="C:\\Program Files\\IDA " + ida_version + "\\ida.exe"
             # XXX - Test the file exists here... We shouldn't rely on a version
             ida32_found = True
 
@@ -336,7 +377,7 @@ if __name__ == "__main__":
                     pass
         else:
             #IDA64="C:\\Program Files (x86)\\IDA 6.95\\idaq64.exe"
-            IDA64="C:\\Program Files\\IDA 7.2\\ida64.exe"
+            IDA64="C:\\Program Files\\IDA " + ida_version + "\\ida64.exe"
             # XXX - Test the file exists here... We shouldn't rely on a version
             ida64_found = True
 
@@ -345,6 +386,7 @@ if __name__ == "__main__":
                 path in IDA32 and IDA64 environment variables, since we can't find them.")
         sys.exit(1)
 
+
     if args.verbose:
         logmsg("IDA32 = %s" % IDA32)
         logmsg("IDA64 = %s" % IDA64)
@@ -352,6 +394,7 @@ if __name__ == "__main__":
     if not args.inputdir:
         logmsg("ERROR: You need to provide an input directory with --inputdir")
         sys.exit()
+
 
     if not os.path.exists(args.inputdir):
         logmsg("ERROR: The path you provided doesn't exist: %s" % args.inputdir)


### PR DESCRIPTION
I have added:

- Automatic PE parsing via the '-a auto' option in order to parse mixed PE files in a folder
- Added fix to get the correct IDA install path via the '--version' option, otherwise finding the correct executable could result in an error